### PR TITLE
Fix gatsby ssr/browser export errors

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,8 +1,6 @@
-import * as React from 'react'
-import { PreviewStoreProvider } from 'gatsby-source-prismic'
+const React = require("react");
+const { PreviewStoreProvider } = require("gatsby-source-prismic");
 
-const wrapRootElement = ({ element }) => (
+exports.wrapRootElement = ({ element }) => (
   <PreviewStoreProvider>{element}</PreviewStoreProvider>
-)
-
-export default wrapRootElement
+);

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,8 +1,6 @@
-import * as React from 'react'
-import { PreviewStoreProvider } from 'gatsby-source-prismic'
+const React = require("react");
+const { PreviewStoreProvider } = require("gatsby-source-prismic");
 
-const wrapRootElement = ({ element }) => (
+exports.wrapRootElement = ({ element }) => (
   <PreviewStoreProvider>{element}</PreviewStoreProvider>
-)
-
-export default wrapRootElement
+);


### PR DESCRIPTION
Fixes the following errors that appear when running `gatsby develop` by changing to the CommonJS syntax.

```
ERROR #11329 

Your plugins must export known APIs from their gatsby-browser.js.

See https://www.gatsbyjs.org/docs/browser-apis/ for the list of Gatsby browser APIs.

- Your local gatsby-browser.js is using the API "export default wrapRootElement" which is not a known API.

Some of the following may help fix the error(s):

- Rename "export default wrapRootElement" -> "wrapRootElement"


 ERROR #11329 

Your plugins must export known APIs from their gatsby-ssr.js.

See https://www.gatsbyjs.org/docs/ssr-apis/ for the list of Gatsby ssr APIs.

- Your local gatsby-ssr.js is using the API "export default wrapRootElement" which is not a known API.

Some of the following may help fix the error(s):

- Rename "export default wrapRootElement" -> "wrapRootElement"
```