### PR TITLE
Fix Prismic Previews

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,8 +1,6 @@
 import * as React from 'react'
 import { PreviewStoreProvider } from 'gatsby-source-prismic'
 
-const wrapRootElement = ({ element }) => (
-  <PreviewStoreProvider>{element}</PreviewStoreProvider>
+export const wrapRootElement = ({ element }) => (
+  <PreviewStoreProvider initialEnabled={true}>{element}</PreviewStoreProvider>
 )
-
-export default wrapRootElement


### PR DESCRIPTION
This can't be a default export, but needs to be a named export. More information here: https://github.com/angeloashmore/gatsby-source-prismic/issues/326