### PR TITLE
feat: update @prismicio/helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "gatsby-multi-language-website",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prismicio/helpers": "^2.0.0-beta.5",
+        "@prismicio/helpers": "^2.0.0-beta.7",
         "@prismicio/react": "^2.0.0-beta.7",
         "gatsby": "^4.0.2",
         "gatsby-plugin-image": "^2.0.0",
@@ -2811,12 +2811,12 @@
       }
     },
     "node_modules/@prismicio/helpers": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@prismicio/helpers/-/helpers-2.0.0-beta.5.tgz",
-      "integrity": "sha512-uKBlcf/N1pFXfJy4vruqqr6Uimcf20g7WDT/4cd3iA8Q3rRr9ZKnxqYD+B1zVwDH+/4YZSz8pPNGuzAbDY+lEQ==",
+      "version": "2.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@prismicio/helpers/-/helpers-2.0.0-beta.7.tgz",
+      "integrity": "sha512-IyHjBxm4KLpytK7ROXD2AMeEuA7lh8pjR6dRgG1YyVHgjD/yqLBkx0HbRJrz31ifb41Fot/uxMahfzr/+NW7Eg==",
       "dependencies": {
-        "@prismicio/richtext": "^2.0.0-beta.2",
-        "@prismicio/types": "^0.1.18",
+        "@prismicio/richtext": "^2.0.0-beta.3",
+        "@prismicio/types": "^0.1.19",
         "escape-html": "^1.0.3"
       },
       "engines": {
@@ -2845,20 +2845,20 @@
       }
     },
     "node_modules/@prismicio/richtext": {
-      "version": "2.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@prismicio/richtext/-/richtext-2.0.0-beta.2.tgz",
-      "integrity": "sha512-S/6APo8hTxB2JoidViujTzIKZ7weU4X9pddsmyNr72BaurMgM5raG4HFRii/Auhaanyf34aGdU1/CrfdoWB3+Q==",
+      "version": "2.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@prismicio/richtext/-/richtext-2.0.0-beta.3.tgz",
+      "integrity": "sha512-ubaaMFsdry7Jwm5H63jBr7jYXP6b/pMNbwRaEH+wUOFmD9lq22r+C6Gait3FNPG//xyqgV3oaI6W1COTiUDnIQ==",
       "dependencies": {
-        "@prismicio/types": "^0.1.18"
+        "@prismicio/types": "^0.1.19"
       },
       "engines": {
         "node": ">=12.7.0"
       }
     },
     "node_modules/@prismicio/types": {
-      "version": "0.1.18",
-      "resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.1.18.tgz",
-      "integrity": "sha512-vO1fNFPGlIld44JiykeevariyZfA44Ihb4P52s4zqz9xBdNY5O3u8V6i+ObwOhrTFjZ0kHIG9KfTPrN3NvKAQA==",
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.1.19.tgz",
+      "integrity": "sha512-nMJ71C86LghZmKLZm40wIeGk5bkZvLsIK9YWy4EUE+1pO/rmVQYvOJcl83zpL8UcvbZXhR3+ZgDG2MO/+b5/sg==",
       "engines": {
         "node": ">=12.7.0"
       }
@@ -24273,12 +24273,12 @@
       "integrity": "sha512-/QeHmNzEtOMtEAZF7ZfRSSosSXGhA4dzQm7vczhxdBGIT23Bbj+h0I4hNlpJZ4n0UzmIYWtd45jYCguVo3hfqQ=="
     },
     "@prismicio/helpers": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@prismicio/helpers/-/helpers-2.0.0-beta.5.tgz",
-      "integrity": "sha512-uKBlcf/N1pFXfJy4vruqqr6Uimcf20g7WDT/4cd3iA8Q3rRr9ZKnxqYD+B1zVwDH+/4YZSz8pPNGuzAbDY+lEQ==",
+      "version": "2.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@prismicio/helpers/-/helpers-2.0.0-beta.7.tgz",
+      "integrity": "sha512-IyHjBxm4KLpytK7ROXD2AMeEuA7lh8pjR6dRgG1YyVHgjD/yqLBkx0HbRJrz31ifb41Fot/uxMahfzr/+NW7Eg==",
       "requires": {
-        "@prismicio/richtext": "^2.0.0-beta.2",
-        "@prismicio/types": "^0.1.18",
+        "@prismicio/richtext": "^2.0.0-beta.3",
+        "@prismicio/types": "^0.1.19",
         "escape-html": "^1.0.3"
       }
     },
@@ -24292,17 +24292,17 @@
       }
     },
     "@prismicio/richtext": {
-      "version": "2.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@prismicio/richtext/-/richtext-2.0.0-beta.2.tgz",
-      "integrity": "sha512-S/6APo8hTxB2JoidViujTzIKZ7weU4X9pddsmyNr72BaurMgM5raG4HFRii/Auhaanyf34aGdU1/CrfdoWB3+Q==",
+      "version": "2.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@prismicio/richtext/-/richtext-2.0.0-beta.3.tgz",
+      "integrity": "sha512-ubaaMFsdry7Jwm5H63jBr7jYXP6b/pMNbwRaEH+wUOFmD9lq22r+C6Gait3FNPG//xyqgV3oaI6W1COTiUDnIQ==",
       "requires": {
-        "@prismicio/types": "^0.1.18"
+        "@prismicio/types": "^0.1.19"
       }
     },
     "@prismicio/types": {
-      "version": "0.1.18",
-      "resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.1.18.tgz",
-      "integrity": "sha512-vO1fNFPGlIld44JiykeevariyZfA44Ihb4P52s4zqz9xBdNY5O3u8V6i+ObwOhrTFjZ0kHIG9KfTPrN3NvKAQA=="
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.1.19.tgz",
+      "integrity": "sha512-nMJ71C86LghZmKLZm40wIeGk5bkZvLsIK9YWy4EUE+1pO/rmVQYvOJcl83zpL8UcvbZXhR3+ZgDG2MO/+b5/sg=="
     },
     "@reach/dialog": {
       "version": "0.16.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Multi-language website example with Gatsby.js using Prismic headless CMS",
   "author": "Prismic",
   "dependencies": {
-    "@prismicio/helpers": "^2.0.0-beta.5",
+    "@prismicio/helpers": "^2.0.0-beta.7",
     "@prismicio/react": "^2.0.0-beta.7",
     "gatsby": "^4.0.2",
     "gatsby-plugin-image": "^2.0.0",

--- a/prismic-configuration.js
+++ b/prismic-configuration.js
@@ -7,7 +7,7 @@ module.exports = {
   // your repository.
   //
   // Example: 'my-repo' if your Prismic repository URL is 'my-repo.prismic.io'.
-  prismicRepo: 'gatsby-multi-language-site-angeloashmore',
+  prismicRepo: 'your-repo-name',
 
   // The default language for content in your Prismic repository.
   defaultLanguage: 'en-us',

--- a/prismic-configuration.js
+++ b/prismic-configuration.js
@@ -7,7 +7,7 @@ module.exports = {
   // your repository.
   //
   // Example: 'my-repo' if your Prismic repository URL is 'my-repo.prismic.io'.
-  prismicRepo: 'your-repo-name',
+  prismicRepo: 'gatsby-multi-language-site-angeloashmore',
 
   // The default language for content in your Prismic repository.
   defaultLanguage: 'en-us',

--- a/src/slices/EmailSignup.js
+++ b/src/slices/EmailSignup.js
@@ -15,12 +15,12 @@ export const EmailSignup = ({ slice }) => (
         className="email-input"
         type="text"
         name="FirstName"
-        placeholder={asText(slice.primary.input_placeholder.richText || [])}
+        placeholder={asText(slice.primary.input_placeholder.richText)}
       />
       <input
         className="btn"
         type="submit"
-        value={asText(slice.primary.button_text.richText || [])}
+        value={asText(slice.primary.button_text.richText)}
       />
     </div>
   </section>


### PR DESCRIPTION
This PR updates `@prismicio/helpers` to `v2.0.0-beta.7`. This version allows passing nullish field values to `asText()` which means we can remove the `[]` fallback.